### PR TITLE
Correctly handle uri encoded query string and "mixed" content

### DIFF
--- a/rawhttp-core/src/main/java/rawhttp/core/RequestLine.java
+++ b/rawhttp-core/src/main/java/rawhttp/core/RequestLine.java
@@ -60,12 +60,19 @@ public class RequestLine implements StartLine {
             if (!host.matches("[a-z]{1,6}://.*")) {
                 host = "http://" + host;
             }
-            URI hostURI = URI.create(host);
-            URI newURI = new URI(hostURI.getScheme(),
-                    hostURI.getUserInfo(),
-                    hostURI.getHost(),
-                    hostURI.getPort(),
-                    uri.getPath(), uri.getQuery(), uri.getFragment());
+            URI hostURI = new URI(host);
+            StringBuilder sb = new StringBuilder(hostURI.toString());
+            if (uri.getRawPath() != null)
+                sb.append(uri.getRawPath());
+            if (uri.getRawQuery() != null) {
+                sb.append('?');
+                sb.append(uri.getRawQuery());
+            }
+            if (uri.getRawFragment() != null) {
+                sb.append('#');
+                sb.append(uri.getRawFragment());
+            }
+            URI newURI = new URI(sb.toString());
             return new RequestLine(method, newURI, httpVersion);
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid host format" + Optional.ofNullable(
@@ -86,18 +93,14 @@ public class RequestLine implements StartLine {
      */
     @Override
     public String toString() {
-        URI pathURI;
-        String path = uri.getPath();
+        String path = uri.getRawPath();
         if (path == null || path.trim().isEmpty()) {
             path = "/";
         }
-        try {
-            // only path and query are sent to the server
-            pathURI = new URI(null, null, null, -1, path, uri.getQuery(), null);
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+        if (uri.getRawQuery() != null) {
+            path += "?" + uri.getRawQuery();
         }
 
-        return method + " " + pathURI + " " + httpVersion;
+        return method + " " + path + " " + httpVersion;
     }
 }

--- a/rawhttp-core/src/test/kotlin/rawhttp/core/HttpMetadataParserTest.kt
+++ b/rawhttp-core/src/test/kotlin/rawhttp/core/HttpMetadataParserTest.kt
@@ -281,6 +281,8 @@ class HttpMetadataParserTest {
                 UriExample("/user/{user-id}", "http", null, null, -1, "/user/%7Buser-id%7D", null, null),
                 UriExample("/id/{0x0}?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&another=%7B%22json%22%3A%20null%7D", "http", null, null, -1,
                         "/id/%7B0x0%7D", "encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&another=%7B%22json%22%3A%20null%7D", null),
+                UriExample("/path%20space?legal=(%26)&illegal=%-1", "http", null, null, -1, "/path%20space", "legal=(%26)&illegal=%25-1", null),
+                UriExample("/yen-%E5%86%86?gbp=%C2%A3", "http", null, null, -1, "/yen-円", "gbp=%C2%A3", null),
                 UriExample("x://admin@hello", "x", "admin", "hello", -1, "", null, null),
                 UriExample("x://admin:pass@hello.com/hi?boo&bar#abc", "x", "admin:pass", "hello.com", -1, "/hi", "boo&bar", "abc"),
                 UriExample("https://admin:pass@hello:8443/hi?boo&bar#abc", "https", "admin:pass", "hello", 8443, "/hi", "boo&bar", "abc"),

--- a/rawhttp-core/src/test/kotlin/rawhttp/core/HttpMetadataParserTest.kt
+++ b/rawhttp-core/src/test/kotlin/rawhttp/core/HttpMetadataParserTest.kt
@@ -278,6 +278,9 @@ class HttpMetadataParserTest {
                 UriExample("hi#a?b", "http", null, "hi", -1, "", null, "a?b"),
                 UriExample("hi?a#d", "http", null, "hi", -1, "", "a", "d"),
                 UriExample("hi?a!#d@f", "http", null, "hi", -1, "", "a!", "d@f"),
+                UriExample("/user/{user-id}", "http", null, null, -1, "/user/%7Buser-id%7D", null, null),
+                UriExample("/id/{0x0}?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&another=%7B%22json%22%3A%20null%7D", "http", null, null, -1,
+                        "/id/%7B0x0%7D", "encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&another=%7B%22json%22%3A%20null%7D", null),
                 UriExample("x://admin@hello", "x", "admin", "hello", -1, "", null, null),
                 UriExample("x://admin:pass@hello.com/hi?boo&bar#abc", "x", "admin:pass", "hello.com", -1, "/hi", "boo&bar", "abc"),
                 UriExample("https://admin:pass@hello:8443/hi?boo&bar#abc", "https", "admin:pass", "hello", 8443, "/hi", "boo&bar", "abc"),
@@ -300,7 +303,7 @@ class HttpMetadataParserTest {
             uri.userInfo shouldEqual userInfo
             uri.host shouldEqual host
             uri.port shouldEqual port
-            uri.path shouldEqual path
+            uri.rawPath shouldEqual path
             uri.rawQuery shouldEqual query
             uri.rawFragment shouldEqual fragment
         }

--- a/rawhttp-core/src/test/kotlin/rawhttp/core/RawHttpTest.kt
+++ b/rawhttp-core/src/test/kotlin/rawhttp/core/RawHttpTest.kt
@@ -74,11 +74,11 @@ class SimpleHttpRequestTests : StringSpec({
     }
 
     "Uses Host header to identify target server if missing from method line - preserve url encoding" {
-        RawHttp().parseRequest("GET /hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd\nHost: www.example.com").eagerly().run {
+        RawHttp().parseRequest("GET /hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&%7B%22json%22%3A%20null%7D\nHost: www.example.com").eagerly().run {
             method shouldBe "GET"
             startLine.httpVersion shouldBe HttpVersion.HTTP_1_1 // the default
-            uri shouldEqual URI.create("http://www.example.com/hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd")
-            toString() shouldBe "GET /hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd HTTP/1.1\r\nHost: www.example.com\r\n\r\n"
+            uri shouldEqual URI.create("http://www.example.com/hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&%7B%22json%22%3A%20null%7D")
+            toString() shouldBe "GET /hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&%7B%22json%22%3A%20null%7D HTTP/1.1\r\nHost: www.example.com\r\n\r\n"
             headers.asMap() shouldEqual mapOf("HOST" to listOf("www.example.com"))
             body should notBePresent()
         }

--- a/rawhttp-core/src/test/kotlin/rawhttp/core/RawHttpTest.kt
+++ b/rawhttp-core/src/test/kotlin/rawhttp/core/RawHttpTest.kt
@@ -73,6 +73,17 @@ class SimpleHttpRequestTests : StringSpec({
         }
     }
 
+    "Uses Host header to identify target server if missing from method line - preserve url encoding" {
+        RawHttp().parseRequest("GET /hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd\nHost: www.example.com").eagerly().run {
+            method shouldBe "GET"
+            startLine.httpVersion shouldBe HttpVersion.HTTP_1_1 // the default
+            uri shouldEqual URI.create("http://www.example.com/hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd")
+            toString() shouldBe "GET /hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd HTTP/1.1\r\nHost: www.example.com\r\n\r\n"
+            headers.asMap() shouldEqual mapOf("HOST" to listOf("www.example.com"))
+            body should notBePresent()
+        }
+    }
+
     "Uses request-line URI Host instead of Host header to identify target server if both are given" {
         RawHttp().parseRequest("GET http://favorite.host/hello\nHost: www.example.com").eagerly().run {
             method shouldBe "GET"

--- a/rawhttp-core/src/test/kotlin/rawhttp/core/RawHttpTest.kt
+++ b/rawhttp-core/src/test/kotlin/rawhttp/core/RawHttpTest.kt
@@ -74,11 +74,11 @@ class SimpleHttpRequestTests : StringSpec({
     }
 
     "Uses Host header to identify target server if missing from method line - preserve url encoding" {
-        RawHttp().parseRequest("GET /hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&%7B%22json%22%3A%20null%7D\nHost: www.example.com").eagerly().run {
+        RawHttp().parseRequest("GET /hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&json=%7B%22a%22%3A%20null%7D\nHost: www.example.com").eagerly().run {
             method shouldBe "GET"
             startLine.httpVersion shouldBe HttpVersion.HTTP_1_1 // the default
-            uri shouldEqual URI.create("http://www.example.com/hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&%7B%22json%22%3A%20null%7D")
-            toString() shouldBe "GET /hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&%7B%22json%22%3A%20null%7D HTTP/1.1\r\nHost: www.example.com\r\n\r\n"
+            uri shouldEqual URI.create("http://www.example.com/hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&json=%7B%22a%22%3A%20null%7D")
+            toString() shouldBe "GET /hello?encoded=%2F%2Fencoded%3Fa%3Db%26c%3Dd&json=%7B%22a%22%3A%20null%7D HTTP/1.1\r\nHost: www.example.com\r\n\r\n"
             headers.asMap() shouldEqual mapOf("HOST" to listOf("www.example.com"))
             body should notBePresent()
         }

--- a/rawhttp-core/src/test/kotlin/rawhttp/core/RequestLineTest.kt
+++ b/rawhttp-core/src/test/kotlin/rawhttp/core/RequestLineTest.kt
@@ -52,8 +52,7 @@ class RequestLineTest : StringSpec({
                 headers("Request line", "Expected version", "Expected method", "Expected path", "Expected String"),
                 row("GET /hi there HTTP/1.1", HttpVersion.HTTP_1_1, "GET", "/hi%20there", "GET /hi%20there HTTP/1.1"),
                 row("POST /api/users/test@example.com HTTP/1.1", HttpVersion.HTTP_1_1,
-                        "POST", "/api/users/test@example.com", "POST /api/users/test@example.com HTTP/1.1"),
-                row("GET /user/{user-id} HTTP/1.1", HttpVersion.HTTP_1_1, "GET", "/user/%7Buser-id%7D", "GET /user/%7Buser-id%7D HTTP/1.1")
+                        "POST", "/api/users/test@example.com", "POST /api/users/test@example.com HTTP/1.1")
         )
 
         forAll(table) { requestLine, expectedVersion, expectedMethod, expectedPath, expectedString ->

--- a/rawhttp-core/src/test/kotlin/rawhttp/core/RequestLineTest.kt
+++ b/rawhttp-core/src/test/kotlin/rawhttp/core/RequestLineTest.kt
@@ -52,7 +52,8 @@ class RequestLineTest : StringSpec({
                 headers("Request line", "Expected version", "Expected method", "Expected path", "Expected String"),
                 row("GET /hi there HTTP/1.1", HttpVersion.HTTP_1_1, "GET", "/hi%20there", "GET /hi%20there HTTP/1.1"),
                 row("POST /api/users/test@example.com HTTP/1.1", HttpVersion.HTTP_1_1,
-                        "POST", "/api/users/test@example.com", "POST /api/users/test@example.com HTTP/1.1")
+                        "POST", "/api/users/test@example.com", "POST /api/users/test@example.com HTTP/1.1"),
+                row("GET /user/{user-id} HTTP/1.1", HttpVersion.HTTP_1_1, "GET", "/user/%7Buser-id%7D", "GET /user/%7Buser-id%7D HTTP/1.1")
         )
 
         forAll(table) { requestLine, expectedVersion, expectedMethod, expectedPath, expectedString ->


### PR DESCRIPTION
This change enables parsing of (legal) query strings with encoded "&".
It also allows such query strings to be parsed correctly with "allowIllegalCharacters".