### PR TITLE
allow absolute-form url in start-line

### DIFF
--- a/rawhttp-core/src/main/java/rawhttp/core/HttpMetadataParser.java
+++ b/rawhttp-core/src/main/java/rawhttp/core/HttpMetadataParser.java
@@ -176,8 +176,12 @@ public final class HttpMetadataParser {
         }
 
         URI uri = parseUri(uriPart);
-
-        return new RequestLine(method, uri, httpVersion);
+        if (!options.allowAbsoluteFormUrl()){
+            if (!uri.getScheme().equalsIgnoreCase("https") && uriPart.toLowerCase().startsWith("http://")){
+                return new RequestLine(method, uri, httpVersion, true);
+            }
+        }
+        return new RequestLine(method, uri, httpVersion, false);
     }
 
     /**

--- a/rawhttp-core/src/main/java/rawhttp/core/HttpMetadataParser.java
+++ b/rawhttp-core/src/main/java/rawhttp/core/HttpMetadataParser.java
@@ -181,7 +181,7 @@ public final class HttpMetadataParser {
                 return new RequestLine(method, uri, httpVersion, true);
             }
         }
-        return new RequestLine(method, uri, httpVersion, false);
+        return new RequestLine(method, uri, httpVersion);
     }
 
     /**

--- a/rawhttp-core/src/main/java/rawhttp/core/RawHttpOptions.java
+++ b/rawhttp-core/src/main/java/rawhttp/core/RawHttpOptions.java
@@ -18,7 +18,7 @@ import static java.util.Objects.requireNonNull;
 public class RawHttpOptions {
 
     private static final RawHttpOptions DEFAULT_INSTANCE = Builder.newBuilder().build();
-
+    private final boolean allowAbsoluteFormUrl;
     private final boolean insertHostHeaderIfMissing;
     private final boolean insertHttpVersionIfMissing;
     private final boolean allowNewLineWithoutReturn;
@@ -34,6 +34,7 @@ public class RawHttpOptions {
                            boolean ignoreLeadingEmptyLine,
                            boolean allowIllegalStartLineCharacters,
                            boolean allowComments,
+                           boolean allowAbsoluteFormUrl,
                            HttpHeadersOptions httpHeadersOptions,
                            HttpBodyEncodingRegistry encodingRegistry) {
         this.insertHostHeaderIfMissing = insertHostHeaderIfMissing;
@@ -42,6 +43,7 @@ public class RawHttpOptions {
         this.ignoreLeadingEmptyLine = ignoreLeadingEmptyLine;
         this.allowIllegalStartLineCharacters = allowIllegalStartLineCharacters;
         this.allowComments = allowComments;
+        this.allowAbsoluteFormUrl = allowAbsoluteFormUrl;
         this.httpHeadersOptions = httpHeadersOptions;
         this.encodingRegistry = encodingRegistry;
     }
@@ -98,6 +100,13 @@ public class RawHttpOptions {
      */
     public boolean ignoreLeadingEmptyLine() {
         return ignoreLeadingEmptyLine;
+    }
+
+    /**
+     * @return whether or not to allow absolute-form url in start-line.
+     */
+    public boolean allowAbsoluteFormUrl() {
+        return allowAbsoluteFormUrl;
     }
 
     /**
@@ -197,6 +206,7 @@ public class RawHttpOptions {
         private boolean insertHttpVersionIfMissing = true;
         private boolean allowIllegalStartLineCharacters = false;
         private boolean allowComments = false;
+        private boolean allowAbsoluteFormUrl = false;
         private HttpHeadersOptionsBuilder httpHeadersOptionsBuilder = new HttpHeadersOptionsBuilder();
         private HttpBodyEncodingRegistry encodingRegistry;
 
@@ -287,6 +297,21 @@ public class RawHttpOptions {
         }
 
         /**
+         * Configure {@link RawHttp} to allow absolute-form url in request-line
+         * <p>
+         * this allows client to send absolute-form url in start-line,for example
+         * {@code GET http://example.com/path HTTP/1.1}
+         * will be sent as is instead of  {@code GET /path HTTP/1.1}
+         * <p>
+         * see https://datatracker.ietf.org/doc/html/rfc7230#section-5.3.2
+         * @return this
+         */
+        public Builder allowAbsoluteFormUrl() {
+            this.allowAbsoluteFormUrl = true;
+            return this;
+        }
+
+        /**
          * Allow comments in HTTP messages.
          * <p>
          * Any line before the message body starting with the '#' character will be considered a comment if this option
@@ -332,7 +357,7 @@ public class RawHttpOptions {
                     : encodingRegistry;
 
             return new RawHttpOptions(insertHostHeaderIfMissing, insertHttpVersionIfMissing,
-                    allowNewLineWithoutReturn, ignoreLeadingEmptyLine, allowIllegalStartLineCharacters, allowComments,
+                    allowNewLineWithoutReturn, ignoreLeadingEmptyLine, allowIllegalStartLineCharacters, allowComments, allowAbsoluteFormUrl,
                     httpHeadersOptionsBuilder.getOptions(), registry);
         }
 

--- a/rawhttp-core/src/main/java/rawhttp/core/RequestLine.java
+++ b/rawhttp-core/src/main/java/rawhttp/core/RequestLine.java
@@ -27,7 +27,14 @@ public class RequestLine implements StartLine {
      * @param uri         URI of the request target
      * @param httpVersion HTTP version of the message
      */
-    public RequestLine(String method, URI uri, HttpVersion httpVersion, boolean absoluteFormURI) {
+    public RequestLine(String method, URI uri, HttpVersion httpVersion) {
+        this.method = method;
+        this.uri = uri;
+        this.httpVersion = httpVersion;
+        this.absoluteFormURI = false;
+    }
+
+    public RequestLine(String method, URI uri, HttpVersion httpVersion,boolean absoluteFormURI) {
         this.method = method;
         this.uri = uri;
         this.httpVersion = httpVersion;

--- a/rawhttp-core/src/main/java/rawhttp/core/RequestLine.java
+++ b/rawhttp-core/src/main/java/rawhttp/core/RequestLine.java
@@ -15,6 +15,7 @@ public class RequestLine implements StartLine {
     private final String method;
     private final URI uri;
     private final HttpVersion httpVersion;
+    private final boolean absoluteFormURI;
 
     /**
      * Create a new {@link RequestLine}.
@@ -26,10 +27,11 @@ public class RequestLine implements StartLine {
      * @param uri         URI of the request target
      * @param httpVersion HTTP version of the message
      */
-    public RequestLine(String method, URI uri, HttpVersion httpVersion) {
+    public RequestLine(String method, URI uri, HttpVersion httpVersion, boolean absoluteFormURI) {
         this.method = method;
         this.uri = uri;
         this.httpVersion = httpVersion;
+        this.absoluteFormURI = absoluteFormURI;
     }
 
     /**
@@ -62,7 +64,7 @@ public class RequestLine implements StartLine {
      * @return a copy of this method line, but with the given host
      */
     public RequestLine withHost(String host) {
-        return new RequestLine(method, UriUtil.withHost(uri, host), httpVersion);
+        return new RequestLine(method, UriUtil.withHost(uri, host), httpVersion, absoluteFormURI);
     }
 
     @Override
@@ -88,16 +90,22 @@ public class RequestLine implements StartLine {
         outputStream.write(method.getBytes(StandardCharsets.US_ASCII));
         outputStream.write(' ');
 
-        String path = uri.getRawPath();
-        if (path == null || path.isEmpty()) {
-            outputStream.write('/');
-        } else {
+        String path;
+        if (absoluteFormURI){
+            path = uri.getScheme() + ":" + uri.getSchemeSpecificPart();
             outputStream.write(path.getBytes(StandardCharsets.US_ASCII));
-        }
-        String query = uri.getRawQuery();
-        if (query != null && !query.isEmpty()) {
-            outputStream.write('?');
-            outputStream.write(query.getBytes(StandardCharsets.US_ASCII));
+        } else {
+            path = uri.getRawPath();
+            if (path == null || path.isEmpty()) {
+                outputStream.write('/');
+            } else {
+                outputStream.write(path.getBytes(StandardCharsets.US_ASCII));
+            }
+            String query = uri.getRawQuery();
+            if (query != null && !query.isEmpty()) {
+                outputStream.write('?');
+                outputStream.write(query.getBytes(StandardCharsets.US_ASCII));
+            }
         }
 
         outputStream.write(' ');

--- a/rawhttp-core/src/main/java/rawhttp/core/client/RedirectingRawHttpClient.java
+++ b/rawhttp-core/src/main/java/rawhttp/core/client/RedirectingRawHttpClient.java
@@ -82,7 +82,7 @@ public class RedirectingRawHttpClient<Response> implements RawHttpClient<Respons
             method = request.getMethod();
         }
         return request.withRequestLine(new RequestLine(
-                method, newUri, request.getStartLine().getHttpVersion(),false));
+                method, newUri, request.getStartLine().getHttpVersion()));
     }
 
 }

--- a/rawhttp-core/src/main/java/rawhttp/core/client/RedirectingRawHttpClient.java
+++ b/rawhttp-core/src/main/java/rawhttp/core/client/RedirectingRawHttpClient.java
@@ -82,7 +82,7 @@ public class RedirectingRawHttpClient<Response> implements RawHttpClient<Respons
             method = request.getMethod();
         }
         return request.withRequestLine(new RequestLine(
-                method, newUri, request.getStartLine().getHttpVersion()));
+                method, newUri, request.getStartLine().getHttpVersion(),false));
     }
 
 }


### PR DESCRIPTION
according to rfc-7230,when making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in absolute-form as the request-target. when allowAbsoluteFormUrl enabled,parse and send `GET http://example.com/ HTTP/1.1` as absolute-form instead of `GET / HTTP/1.1`